### PR TITLE
refactor(WikiCacheClient): respect consume range by default

### DIFF
--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -50,7 +50,7 @@ export class DocsCommand extends Command {
       const messageActionRow = new MessageActionRow().setComponents(
         new MessageSelectMenu()
           .setCustomId(SelectMenuIdentifiers.ChoiceSuggestion)
-          .setOptions(docs.map(docsToSelectOption).slice(0, 25))
+          .setOptions(docs.map(docsToSelectOption))
       )
 
       await interaction.editReply({ components: [messageActionRow] })

--- a/src/interaction-handlers/autocomplete/docs.ts
+++ b/src/interaction-handlers/autocomplete/docs.ts
@@ -35,7 +35,7 @@ export class DocsAutoCompleteHandler extends InteractionHandler<{
         if (isNullishOrEmpty(focusedOption.value)) {
           const docs = await this.container.wikiCacheClient.getDocs()
 
-          return this.some(docs.map(docsToChoiceData).slice(0, 25))
+          return this.some(docs.map(docsToChoiceData))
         }
 
         const fuzzyDocs = await this.container.wikiCacheClient //

--- a/src/lib/client/WikiCacheClient.ts
+++ b/src/lib/client/WikiCacheClient.ts
@@ -8,15 +8,17 @@ import { fileURLToPath } from 'node:url'
 
 import { Directories, EnvironmentKeys } from '../utils/constants.js'
 
-interface GetDocumentsOptions {
+interface ConsumeRange {
+  offset?: number
+  take?: number
+}
+
+interface GetDocumentsOptions extends ConsumeRange {
   exclude?: string[]
   cache?: boolean
 }
 
-interface FuzzilySearchDocsOptions {
-  offset?: number
-  take?: number
-}
+type FuzzilySearchDocsOptions = ConsumeRange
 
 interface FuzzilySearchDocsResult {
   name: string
@@ -81,6 +83,7 @@ export class WikiCacheClient {
     const docs = []
     const exclude = options.exclude ?? []
     const excludeFilter = (docs: string): boolean => !exclude.includes(docs)
+    const { offset = 0, take = 25 } = options
 
     const isCache = options.cache ?? true
     if (isCache) {
@@ -91,7 +94,7 @@ export class WikiCacheClient {
       docs.push(...loadedDocs)
     }
 
-    return docs.filter(excludeFilter)
+    return docs.filter(excludeFilter).slice(offset, take)
   }
 
   public async getDocumentLink(document: string): Promise<Option<string>> {


### PR DESCRIPTION
## 📑 Summary
  This pull request includes refactored code in "WikiCacheClient". Currently `#getDocs()` returns all documents without restriction, but it causes the inconvenience of specifying the number of documents when processing Discord SelectMenu choice data. This pull request respects consume range by default, so it resolves potential runtime error.

 **BREAKING CHANGE: `#getDocs()` return maximum 25 by default**